### PR TITLE
update to include minimum version of pandas 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ scipy
 scikit-learn
 statsmodels
 matplotlib
-pandas
+pandas>=0.21


### PR DESCRIPTION
Conversions for df2tab do not work for pandas 0.20.x due to functionality change here in df2tab to support datetime conversions versions>= 0.21.x have been tested fo python 3.6/3.7 with 3.6 our minimum requirement for embedpy