### PR TITLE
Correct code.kx utilities link

### DIFF
--- a/util/README.md
+++ b/util/README.md
@@ -32,7 +32,7 @@ q).ml.loadfile`:util/init.q
 
 ## Documentation
 
-Documentation is available on the [Utilities](https://code.kx.com/v2/ml/toolkit/utils/) homepage.
+Documentation is available on the [Utilities](https://code.kx.com/q/ml/toolkit/utilities/metric/) homepage.
 
 ## Status
   


### PR DESCRIPTION
The old link was dead. You can not link to utilities itself so linking for subsection which is `metric`