### PR TITLE
Update to FRESH distributed execution functionality

### DIFF
--- a/fresh/extract.q
+++ b/fresh/extract.q
@@ -51,9 +51,8 @@ fresh.createFeatures:{[data;idCol;cols2Extract;params]
   allParams:(cross/)each param1`pvals;
   calcs:param0,raze param1[`f]cross'param1[`pnames],'/:'allParams;
   cols2Extract:$[n:"j"$abs system"s";
-    $[n<count cols2Extract;(n;0N);(n)]#;
-    enlist
-    ]cols2Extract;
+    $[n<m:count cols2Extract;(n;0N);m]#;
+    enlist]cols2Extract;
   calcs:cols2Extract cross\:calcs;
   colMapping:fresh.i.colMap each calcs;
   colMapping:(`$ssr[;".";"o"]@''"_"sv''string raze@''calcs)!'colMapping;

--- a/fresh/extract.q
+++ b/fresh/extract.q
@@ -52,7 +52,8 @@ fresh.createFeatures:{[data;idCol;cols2Extract;params]
   calcs:param0,raze param1[`f]cross'param1[`pnames],'/:'allParams;
   cols2Extract:$[n:"j"$abs system"s";
     $[n<m:count cols2Extract;(n;0N);m]#;
-    enlist]cols2Extract;
+    enlist
+    ]cols2Extract;
   calcs:cols2Extract cross\:calcs;
   colMapping:fresh.i.colMap each calcs;
   colMapping:(`$ssr[;".";"o"]@''"_"sv''string raze@''calcs)!'colMapping;


### PR DESCRIPTION
Previously when FRESH was extracting features in distributed mode and the number of features was less than secondary threads excess calculations were being performed,

```
$ q -s -4 -p 1234
KDB+ 4.0 2020.07.15 Copyright (C) 1993-2020 Kx Systems
m64/ 4(16)core 8192MB kx kxs-macbook-air.local 127.0.0.1 EXPIRE 2022.06.22 user@gmail.com KOD #5004989

q)\l ml/ml.q
q).ml.loadfile`:fresh/init.q
q)m:30;n:100
q)tab:([]date:raze m#'"d"$til n;time:(m*n)#"t"$til m;col1:50*1+(m*n)?20;col2:(m*n)?1f)
q)params:.ml.fresh.params 
q).ml.fresh.createFeatures[tab;`date;`col1;params]
'`e+1
  [1]  /Users/kx/opt/anaconda3/q/ml/fresh/extract.q:49: .ml.fresh.createFeatures:{[data;idCol;cols2Extract;params]
  `e+1;
  ^
  param0:exec f from params where valid,pnum=0;
q.ml))param0:exec f from params where valid,pnum=0;
q.ml))param1:exec f,pnames,pvals from params where valid,pnum>0;
q.ml))allParams:(cross/)each param1`pvals;
q.ml))calcs:param0,raze param1[`f]cross'param1[`pnames],'/:'allParams;
q.ml))cols2Extract:$[n:"j"$abs system"s";$[n<count cols2Extract;(n;0N);(n)]#;enlist]cols2Extract;
// As the number of columns is less than the number of slaves, it returns the column 4 times
q.ml))cols2Extract
`col1`col1`col1`col1
// So computations are going to be done 4 times for the same column
q.ml))show calcs:cols2Extract cross\:calcs;
`col1`absEnergy `col1`absSumChange `col1`aggAutoCorr `col1`augFuller `col1`co..
`col1`absEnergy `col1`absSumChange `col1`aggAutoCorr `col1`augFuller `col1`co..
`col1`absEnergy `col1`absSumChange `col1`aggAutoCorr `col1`augFuller `col1`co..
`col1`absEnergy `col1`absSumChange `col1`aggAutoCorr `col1`augFuller `col1`co..
```
This bug has been rectified with the number of calculations now mapping the number of columns on which calculations are to be performed.