### PR TITLE
.ml.ts.acfPlot use til on lags

### DIFF
--- a/timeseries/misc.q
+++ b/timeseries/misc.q
@@ -105,7 +105,7 @@ ts.laggedFeatures:{[tab;colNames;lags]
 // @param n {int} Number of lags to include in the graph
 // @return {graph} display to standard out the autocorrelation bar plot
 ts.acfPlot:{[data;n;width]
-  acf:ts.i.autoCorrFunction[data;]each n;
+  acf:ts.i.autoCorrFunction[data;]each n:til n;
   ts.i.plotFunction[data;acf;n;width;"AutoCorrelation"];
   }
 


### PR DESCRIPTION
Raised by user on [StackOverflow](https://stackoverflow.com/questions/69516318/how-do-i-calculate-the-autocorrelation-using-kdb-ml-ts).

The function should plot an item per lag which meant `n: til n` needed to be inserted.



![acfPlot](https://user-images.githubusercontent.com/11801577/136775748-6315145b-4224-4f9c-9ae4-43222b025353.JPG)

