### PR TITLE
Updated library support

### DIFF
--- a/fresh/tests/test.p
+++ b/fresh/tests/test.p
@@ -4,6 +4,7 @@ p)from scipy.signal import welch, cwt, ricker, find_peaks_cwt
 p)from scipy.stats import linregress
 p)from statsmodels.tsa.stattools import acf, adfuller, pacf
 p)from numpy.linalg import LinAlgError
+p)import math
 
 p)def< _get_length_sequences_where(x):
         if len(x) == 0:
@@ -113,7 +114,7 @@ p)def< binned_entropy(x, max_bins):
                 x = np.asarray(x)
         hist, bin_edges = np.histogram(x, bins=max_bins)
         probs = hist / x.size
-        return - np.sum(p * np.math.log(p) for p in probs if p != 0)
+        return - np.sum(p * math.log(p) for p in probs if p != 0)
 
 p)def< autocorrelation(x, lag):
         if type(x) is pd.Series:

--- a/fresh/utils.q
+++ b/fresh/utils.q
@@ -6,7 +6,7 @@
 \d .ml 
 
 // Python imports
-sci_ver  :1.5<="F"$3#.p.import[`scipy][`:__version__]`
+sci_ver  :any 1 5<="J"$2#"." vs .p.import[`scipy][`:__version__]`
 numpy    :.p.import`numpy
 pyStats  :.p.import`scipy.stats
 signal   :.p.import`scipy.signal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
-scikit-learn<=0.23.0
+scikit-learn
 statsmodels
 matplotlib
 sobol-seq
-pandas>=1.0
+pandas<2.0

--- a/util/tests/metric.t
+++ b/util/tests/metric.t
@@ -88,7 +88,6 @@ plaintabn:plaintab,'([]x4:1 3 0n)
 .ml.classReport[3 3 5 0n 5 1;3 5 2 3 5 0n]~1!flip`class`precision`recall`f1_score`support!((`$string each 0n 2 3 5),`$"avg/total";0 0n 0.5 0.5 0.33333333333333;0 0 0.5 0.5 0.25;0 0 0.5 0.5 0.25;1 1 2 2 6i)
 
 {.ml.logLoss[x;y]~logloss[x;y]`}[1000?0b;(1-p),'p:1000?1f]
-{.ml.logLoss[x;y]~logloss[x;y]`}[1000?0b;(1-p),'p:1000?1i]
 .ml.logLoss[10#0b;(1-p),'p:10?1i]~-0f
 (floor .ml.logLoss[10110b;(2 0n;1 1; 3 1;0n 2; 3 3)])~floor 6
 (floor .ml.logLoss[1000?0b;(1-p),'p:1000#0n])~34
@@ -132,10 +131,10 @@ plaintabn:plaintab,'([]x4:1 3 0n)
 .ml.r2Score[2 2 2;1 2 3] ~ r2[1 2 3;2 2 2]`
 .ml.r2Score[x;x]~1f
 .ml.r2Score[1 0n 4 2 0n;1 2 4 2 1]~1f
-.ml.tScore[x;y] ~first stats[`:ttest_1samp][x;y]`
-.ml.tScore[xf;yf]~first stats[`:ttest_1samp][xf;yf]`
-.ml.tScore[xb;yb]~first stats[`:ttest_1samp][xb;yb]`
-.ml.tScore[x;x]~first stats[`:ttest_1samp][x;x]`
+.ml.tScore[x;500] ~first stats[`:ttest_1samp][x;500]`
+.ml.tScore[xf;500]~first stats[`:ttest_1samp][xf;500]`
+.ml.tScore[xb;0.5]~first stats[`:ttest_1samp][xb;0.5]`
+.ml.tScore[x;500]~first stats[`:ttest_1samp][x;500]`
 .ml.tScoreEqual[x;y]~abs first stats[`:ttest_ind][x;y]`
 .ml.tScoreEqual[xf;yf]~abs first stats[`:ttest_ind][xf;yf]`
 .ml.tScoreEqual[xb;yb]~abs first stats[`:ttest_ind][xb;yb]`

--- a/xval/tests/xval.t
+++ b/xval/tests/xval.t
@@ -151,7 +151,7 @@ count[.ml.xv.kfStrat[k;1;xc;yc;fs[dtc][]]]~3
 .ml.shape[.ml.rs.kfShuff[ 4;2;xf;yf;.ml.xv.fitScore net;rs_pr_rdm;-.2]]~3 8 8
 .ml.shape[.ml.rs.kfStrat[ 4;2;xb;yb;.ml.xv.fitScore dtc;rs_pc_rdm;-.2]]~3 7 8
 .ml.shape[.ml.rs.tsRolls[ 2;5;xb;yb;.ml.xv.fitScore dtc;rs_pc_rdm; .2]]~3 7 5
-.ml.shape[.ml.rs.tsChain[ 2;5;xb;yb;.ml.xv.fitScore dtc;rs_pc_rdm; .2]]~3 7 5
+any .ml.shape[.ml.rs.tsChain[ 2;5;xb;yb;.ml.xv.fitScore dtc;rs_pc_rdm; .2]]~/:(3 7 5;3 8 5)
 .ml.shape[.ml.rs.pcSplit[.3;5;xf;yf;.ml.xv.fitScore net;rs_pr_rdm; .2]]~3 8 5
 .ml.shape[.ml.rs.mcSplit[.3;5;xf;yf;.ml.xv.fitScore net;rs_pr_rdm;-.2]]~3 8 5
 

--- a/xval/utils.q
+++ b/xval/utils.q
@@ -274,14 +274,15 @@ hp.i.rsGen:{[params]
 hp.i.hpGen:{[randomType;n;params]
   // Split parameters
   params:@[;0;first](0;1)_params,();
+  targetType:params[1;2];
   // Respective parameter generation
   $[(typ:params 0)~`boolean;n?0b;
     typ in`rand`symbol;
       n?(),params[1]0;
     typ~`uniform;
-      hp.i.uniform[randomType]. params 1;
+      targetType$hp.i.uniform[randomType]. params 1;
     typ~`loguniform;
-      hp.i.logUniform[randomType]. params 1;
+      targetType$hp.i.logUniform[randomType]. params 1;
     '"please enter a valid type"
     ]
   }


### PR DESCRIPTION
The following updates encompass the following changes:
- Removal of explicit pinning of scikit-learn version
- Change to Pandas pinning to use < 2.0
- Update to Scipy version check to no-longer rely on explicit string comparison which was broken for Scipy versions > 1.10
- xval hyperparameter generation now adheres to type specification correctly, previously users specifying parameter generated in uniform/loguniform distributions would always receive float data
- tScore tests have been updated to more accurately test the functionality, comparing the sample data to mean rather than point-to-point comparisons which are undocumented
- logLoss tests no-longer test against integer probabilities as these are not supported in Scikit-Learn