### PR TITLE
Performance improvements for q table to pandas DataFrame

### DIFF
--- a/util/utilities.q
+++ b/util/utilities.q
@@ -108,6 +108,7 @@ trainTestSplit:{[data;target;size]
 // @param tab {table} A q table
 // @return {<} a Pandas dataframe
 tab2df:{
+  keyTab:keys x;
   c:cols x:0!x;
   c1:i.findCols[x;"bxhijef"]; 
   df:i.pandasDF[{$[count y;y!x y;()!()]}[x;c1]];
@@ -127,7 +128,7 @@ tab2df:{
   // Reorder the columns based on initial input
   df:df[`:reindex][`columns pykw c];
   // Index the table if originally keyed
-  $[count keyTab:keys x;
+  $[count keyTab;
     df[`:set_index]keyTab;
     df
     ]

--- a/util/utilities.q
+++ b/util/utilities.q
@@ -107,15 +107,31 @@ trainTestSplit:{[data;target;size]
 // @desc Convert q table to Pandas dataframe
 // @param tab {table} A q table
 // @return {<} a Pandas dataframe
-tab2df:{[tab]
-  updTab:@[flip 0!tab;i.findCols[tab;"c"];enlist each];
-  transformTab:@[updTab;i.findCols[tab]"pmdznuvt";i.q2npDate];
-  pandasDF:i.pandasDF[transformTab][@;cols tab];
-  $[count keyTab:keys tab;
-    pandasDF[`:set_index]keyTab;
-    pandasDF
+tab2df:{
+  c:cols x:0!x;
+  c1:i.findCols[x;"bxhijef"]; 
+  df:i.pandasDF[{$[count y;y!x y;()!()]}[x;c1]];
+  cls:c except c1;
+  // Early exit if only numeric columns existed
+  if[0=count cls;:df];
+  updTab:@[flip x;i.findCols[x;"c"];enlist each];
+  // Convert temporal columns to timestamps and
+  // assign as datetime64[ns] columns
+  timeCols:i.findCols[x;"pmdznuvt"];
+  timeTab:?[updTab;();0b;timeCols!timeCols];
+  timeTab:@[timeTab;timeCols;{("p"$@[4#+["d"$0];-16+type x]x)-"p"$1970.01m}];
+  df:{x[`:assign][z pykw i.npArray[y z;"datetime64[ns]"]]}/[df;count[timeCols]#enlist timeTab;timeCols];
+  // Convert symbols to strings (both reconcile to same type, char vector conversions are faster)
+  // otherwise assign the underlying datatype
+  {x[=;z;enlist $[11h=type dat:y z;string dat;dat]]}[df;updTab]each cls except timeCols;
+  // Reorder the columns based on initial input
+  df:df[`:reindex][`columns pykw c];
+  // Index the table if originally keyed
+  $[count keyTab:keys x;
+    df[`:set_index]keyTab;
+    df
     ]
-  }
+ }
 
 // @kind function
 // @category utilities

--- a/util/utils.q
+++ b/util/utils.q
@@ -20,17 +20,6 @@ i.combFunc:{[n;vals]
 // @private
 // @kind function
 // @category utilitiesUtility
-// @desc Transform q object to numpy date
-// @param date {date} q datetime object
-// @return {<} Numpy datetime object
-i.q2npDate:{[date]
-  dateConvert:("p"$@[4#+["d"$0];-16+type date]date)-"p"$1970.01m;
-  .p.import[`numpy;`:array;dateConvert;"datetime64[ns]"]`.
-  }
-
-// @private
-// @kind function
-// @category utilitiesUtility
 // @desc  Convert python float32 function to produce correct precision
 //   Note check for x~()!() which is required in cases where underlying 
 //   representation is float32 for dates/times
@@ -196,6 +185,12 @@ i.dateTime:.p.import`datetime
 // @category utilitiesUtility
 // @desc Python pandas dataframe module
 i.pandasDF:.p.import[`pandas]`:DataFrame
+
+// @private
+// @kind function
+// @category utilitiesUtility
+// @desc Numpy array function
+i.npArray:.p.import[`numpy]`:array
 
 // @private
 // @kind function


### PR DESCRIPTION
Prior to these changes a number of inefficiencies existed when converting q tables to Pandas Dataframes using `.ml.tab2df`,  the changes within this merge request improve this in a number of ways

1. Conversions of symbol columns pre-convert the symbol data to kdb+ string/char vectors prior to passing to Python, since both reconcile to `str` in Python and symbols are less performant when accessing them this provides a significant performance boost
2. For any columns which can be zero copied and inferred from a dictionary we pass these directly into the Pandas Dataframe creation function up front
3. When converting q date/time/timestamp etc the previous conversion to foreign objects and assignment of these objects is less efficient than assigning a column and converting at assignment time

```q
q)N:10000000
q)dat:([]date:2001.01.01; sym:`A; qty:N?100f)
q)\t .ml.tab2df[dat]          // New Implementation
744
q)\t .ml.tab2dfOld[dat]       // Old Implementation
9394
q).ml.df2tab[.ml.tab2df dat]~.ml.df2tab .ml.tab2dfOld[dat]
1b
```

This is intended to resolve this open issue [here](https://github.com/KxSystems/embedPy/issues/119)